### PR TITLE
Conversion in memory and support "broken" LDAP certs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/jimmidyson/pemtokeystore
+
+require (
+	github.com/pavel-v-chernykh/keystore-go v2.0.0+incompatible
+	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jimmidyson/pemtokeystore
 
 require (
-	github.com/pavel-v-chernykh/keystore-go v2.0.0+incompatible
+	github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/pavel-v-chernykh/keystore-go v2.0.0+incompatible h1:P1Qb9RZTHcTmxIFPud52bBozpwlzKg4Hbkzi6oUQ2Xs=
 github.com/pavel-v-chernykh/keystore-go v2.0.0+incompatible/go.mod h1:xlUlxe/2ItGlQyMTstqeDv9r3U4obH7xYd26TbDQutY=
+github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible h1:Jd6xfriVlJ6hWPvYOE0Ni0QWcNTLRehfGPFxr3eSL80=
+github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible/go.mod h1:xlUlxe/2ItGlQyMTstqeDv9r3U4obH7xYd26TbDQutY=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/pavel-v-chernykh/keystore-go v2.0.0+incompatible h1:P1Qb9RZTHcTmxIFPud52bBozpwlzKg4Hbkzi6oUQ2Xs=
+github.com/pavel-v-chernykh/keystore-go v2.0.0+incompatible/go.mod h1:xlUlxe/2ItGlQyMTstqeDv9r3U4obH7xYd26TbDQutY=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pemtokeystore.go
+++ b/pemtokeystore.go
@@ -24,12 +24,22 @@ import (
 	"strings"
 	"time"
 
-	keystore "github.com/pavel-v-chernykh/keystore-go"
+	"github.com/pavel-v-chernykh/keystore-go"
 )
 
 const (
 	DefaultKeystorePassword = "changeit"
 )
+
+type CertConverter struct {
+	PrivateKeys map[string]CertReader
+	Certs       map[string]CertReader
+	CACerts     []CertReader
+	CACertDirs  []string
+
+	SourceKeystorePath     string
+	SourceKeystorePassword string
+}
 
 type Options struct {
 	PrivateKeyFiles map[string]string
@@ -44,42 +54,100 @@ type Options struct {
 	SourceKeystorePassword string
 }
 
+type CertReader interface {
+	Read() ([]byte, error)
+	Describe() string
+}
+
+type FileCert struct {
+	Path string
+}
+
+func (c *FileCert) Read() ([]byte, error) {
+	raw, err := ioutil.ReadFile(c.Path)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func (c *FileCert) Describe() string {
+	return c.Path
+}
+
+type ByteCert struct {
+	Cert []byte
+	Name string
+}
+
+func (c *ByteCert) Read() ([]byte, error) {
+	return c.Cert, nil
+}
+
+func (c *ByteCert) Describe() string {
+	return c.Name
+}
+
 func CreateKeystore(opts Options) error {
-	if len(opts.KeystorePath) == 0 {
-		return fmt.Errorf("Missing keystore path")
+	optsv2 := CertConverter{
+		CACertDirs:             opts.CACertDirs,
+		SourceKeystorePath:     opts.SourceKeystorePath,
+		SourceKeystorePassword: opts.SourceKeystorePassword,
 	}
 
-	keystorePassword := []byte(opts.KeystorePassword)
-	if len(keystorePassword) == 0 {
-		keystorePassword = []byte(DefaultKeystorePassword)
+	if len(opts.PrivateKeyFiles) > 0 {
+		optsv2.PrivateKeys = map[string]CertReader{}
+		for a, f := range opts.PrivateKeyFiles {
+			optsv2.PrivateKeys[a] = &FileCert{Path: f}
+		}
 	}
+
+	if len(opts.CertFiles) > 0 {
+		optsv2.Certs = map[string]CertReader{}
+		for a, f := range opts.CertFiles {
+			optsv2.Certs[a] = &FileCert{Path: f}
+		}
+	}
+
+	if len(opts.CACertFiles) > 0 {
+		optsv2.CACerts = []CertReader{}
+		for _, f := range opts.CACertFiles {
+			optsv2.CACerts = append(optsv2.CACerts, &FileCert{Path: f})
+		}
+	}
+
+	ks, err := optsv2.ConvertCertsToKeystore()
+	if err != nil {
+		return err
+	}
+
+	return WriteKeyStore(ks, opts.KeystorePath, opts.KeystorePassword)
+}
+
+
+func (opts *CertConverter) ConvertCertsToKeystore() (keystore.KeyStore, error) {
 
 	var ks keystore.KeyStore
 	if len(opts.SourceKeystorePath) > 0 {
 		sourceKeystorePassword := []byte(opts.SourceKeystorePassword)
-		if len(keystorePassword) == 0 {
+		if len(sourceKeystorePassword) == 0 {
 			sourceKeystorePassword = []byte(DefaultKeystorePassword)
 		}
 
 		sourceKs, err := readKeyStore(opts.SourceKeystorePath, sourceKeystorePassword)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		ks = sourceKs
 	} else {
-		sourceKs, err := readKeyStore(opts.KeystorePath, keystorePassword)
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
-
-		ks = sourceKs
+		ks = keystore.KeyStore{}
 	}
 
-	for _, caFile := range opts.CACertFiles {
-		caCerts, err := readCACertsFromFile(caFile)
+	for _, caFile := range opts.CACerts {
+		caCerts, err := opts.parseCerts(caFile)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		for alias, cert := range caCerts {
@@ -93,14 +161,14 @@ func CreateKeystore(opts Options) error {
 	for _, caDir := range opts.CACertDirs {
 		files, err := ioutil.ReadDir(caDir)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		for _, file := range files {
 			if file.IsDir() {
 				continue
 			}
-			caCerts, err := readCACertsFromFile(filepath.Join(caDir, file.Name()))
+			caCerts, err := opts.parseCerts(&FileCert{filepath.Join(caDir, file.Name())})
 			if err != nil {
 				continue
 			}
@@ -114,15 +182,15 @@ func CreateKeystore(opts Options) error {
 		}
 	}
 
-	for alias, file := range opts.PrivateKeyFiles {
-		priv, err := privateKeyFromFile(file, keystorePassword)
+	for alias, file := range opts.PrivateKeys {
+		priv, err := opts.privateKeyFromCert(file)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		certs, err := certsFromFile(opts.CertFiles[alias])
+		certs, err := opts.loadCerts(opts.Certs[alias])
 		if err != nil {
-			return err
+			return nil, err
 		}
 		ks[alias] = &keystore.PrivateKeyEntry{
 			Entry:     keystore.Entry{CreationDate: time.Now()},
@@ -131,11 +199,11 @@ func CreateKeystore(opts Options) error {
 		}
 	}
 
-	return writeKeyStore(ks, opts.KeystorePath, keystorePassword)
+	return ks, nil
 }
 
-func readCACertsFromFile(caFile string) (map[string]keystore.Certificate, error) {
-	certs, err := certsFromFile(caFile)
+func (opts *CertConverter) parseCerts(certReader CertReader) (map[string]keystore.Certificate, error) {
+	certs, err := opts.loadCerts(certReader)
 	if err != nil {
 		return nil, err
 	}
@@ -164,13 +232,13 @@ func readCACertsFromFile(caFile string) (map[string]keystore.Certificate, error)
 	return aliasCertMap, nil
 }
 
-func privateKeyFromFile(file string, password []byte) ([]byte, error) {
-	pkbs, err := pemFileToBlocks(file)
+func (opts *CertConverter) privateKeyFromCert(certReader CertReader) ([]byte, error) {
+	pkbs, err := opts.pemToBlocks(certReader)
 	if err != nil {
 		return nil, err
 	}
 	if len(pkbs) != 1 {
-		return nil, fmt.Errorf("failed to single PEM block from file %s", file)
+		return nil, fmt.Errorf("failed to get single PEM block from cert %s", certReader.Describe())
 	}
 
 	var pk interface{}
@@ -191,12 +259,12 @@ func privateKeyFromFile(file string, password []byte) ([]byte, error) {
 	return convertPrivateKeyToPKCS8(pk)
 }
 
-func certsFromFile(file string) ([]keystore.Certificate, error) {
-	if len(file) == 0 {
+func (opts *CertConverter) loadCerts(certReader CertReader) ([]keystore.Certificate, error) {
+	if certReader == nil {
 		return nil, nil
 	}
 
-	cbs, err := pemFileToBlocks(file)
+	cbs, err := opts.pemToBlocks(certReader)
 	if err != nil {
 		return nil, err
 	}
@@ -212,11 +280,12 @@ func certsFromFile(file string) ([]keystore.Certificate, error) {
 	return certs, nil
 }
 
-func pemFileToBlocks(path string) ([]*pem.Block, error) {
-	raw, err := ioutil.ReadFile(path)
+func (opts *CertConverter) pemToBlocks(cert CertReader) ([]*pem.Block, error) {
+	raw, err := cert.Read()
 	if err != nil {
 		return nil, err
 	}
+
 	var (
 		pemBlocks []*pem.Block
 		current   *pem.Block
@@ -228,7 +297,7 @@ func pemFileToBlocks(path string) ([]*pem.Block, error) {
 			if len(pemBlocks) > 0 {
 				return pemBlocks, nil
 			}
-			return nil, fmt.Errorf("failed to decode any PEM blocks from %s", path)
+			return nil, fmt.Errorf("failed to decode any PEM blocks from %s", cert.Describe())
 		}
 		pemBlocks = append(pemBlocks, current)
 		if len(raw) == 0 {
@@ -238,10 +307,19 @@ func pemFileToBlocks(path string) ([]*pem.Block, error) {
 	return pemBlocks, nil
 }
 
-func writeKeyStore(ks keystore.KeyStore, path string, passphrase []byte) error {
+func WriteKeyStore(ks keystore.KeyStore, keystorePath string, password string) error {
+	if len(keystorePath) == 0 {
+		return fmt.Errorf("Missing keystore path")
+	}
+
+	keystorePassword := []byte(password)
+	if len(keystorePassword) == 0 {
+		keystorePassword = []byte(DefaultKeystorePassword)
+	}
+
 	// Let's do this atomically (temp + rename) in case anything is watching (inotify?) on
 	// the keystore itself.
-	absPath, err := filepath.Abs(path)
+	absPath, err := filepath.Abs(keystorePath)
 	if err != nil {
 		return err
 	}
@@ -250,7 +328,7 @@ func writeKeyStore(ks keystore.KeyStore, path string, passphrase []byte) error {
 	if err != nil {
 		return err
 	}
-	err = keystore.Encode(tempFile, ks, passphrase)
+	err = keystore.Encode(tempFile, ks, keystorePassword)
 	tempFile.Close()
 	if err != nil {
 		return err

--- a/pemtokeystore_test.go
+++ b/pemtokeystore_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/pavel-v-chernykh/keystore-go"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -114,15 +115,45 @@ func validateServerCert(caCertFile, url string) error {
 	return nil
 }
 
-func validateKeystoreWithKeytool(t *testing.T) error {
+func validateKeystoreWithKeytool(t *testing.T, path string) error {
+	keystore := testKeystore
+	if path != "" {
+		keystore = path
+	}
 	keytool, err := exec.LookPath("keytool")
 	if err == nil {
-		cmd := exec.Command(keytool, "-list", "-keystore", testKeystore, "-storepass", pemtokeystore.DefaultKeystorePassword)
+		cmd := exec.Command(keytool, "-list", "-keystore", keystore, "-storepass", pemtokeystore.DefaultKeystorePassword)
 		out, err := cmd.CombinedOutput()
 		t.Log(string(out))
 		return err
 	}
 	return nil
+}
+
+func TestCACertConversion(t *testing.T) {
+	contents, err := ioutil.ReadFile(certFile(serverFromIntermediateCAFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	converter := pemtokeystore.CertConverter{
+		CACerts:                []pemtokeystore.CertReader{
+			&pemtokeystore.ByteCert{
+				Cert: contents,
+				Name: "server-from-intermediate",
+			},
+		},
+	}
+	k, err := converter.ConvertCertsToKeystore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	truststore, ok := k["localhost"].(*keystore.TrustedCertificateEntry)
+	if !ok {
+		t.Fatalf("Converted keystore does not contain a trusted certificate entry %v", truststore)
+	}
+	if truststore.Certificate.Type != "X509" {
+		t.Fatalf("Parsed certificate is invalid")
+	}
 }
 
 func TestJavaClientKeystore(t *testing.T) {
@@ -152,7 +183,7 @@ func TestJavaClientKeystore(t *testing.T) {
 			defer ts.Close()
 
 			opts := pemtokeystore.Options{
-				CACertFiles:  []string{certFile(rootCAFile)},
+				CACertFiles:      []string{certFile(rootCAFile)},
 				KeystorePath: testKeystore,
 			}
 			defer os.Remove(testKeystore)
@@ -160,7 +191,7 @@ func TestJavaClientKeystore(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			if err = validateKeystoreWithKeytool(t); err != nil {
+			if err = validateKeystoreWithKeytool(t, ""); err != nil {
 				t.Error(err)
 				return
 			}
@@ -196,16 +227,16 @@ func TestJavaServerKeystore(t *testing.T) {
 	for _, s := range serverCerts {
 		func() {
 			opts := pemtokeystore.Options{
-				PrivateKeyFiles: map[string]string{"server": keyFile(s[0])},
-				CertFiles:       map[string]string{"server": certFile(s[0] + "-bundle")},
-				KeystorePath:    testKeystore,
+				PrivateKeyFiles:  map[string]string{"server": keyFile(s[0])},
+				CertFiles:        map[string]string{"server": certFile(s[0] + "-bundle")},
+				KeystorePath: testKeystore,
 			}
 			//defer os.Remove(testKeystore)
 			if err = pemtokeystore.CreateKeystore(opts); err != nil {
 				t.Error(err)
 				return
 			}
-			if err = validateKeystoreWithKeytool(t); err != nil {
+			if err = validateKeystoreWithKeytool(t, ""); err != nil {
 				t.Error(err)
 				return
 			}

--- a/testdata/create-certs.sh
+++ b/testdata/create-certs.sh
@@ -89,3 +89,26 @@ cfssl gencert -ca root-ca.pem -ca-key root-ca-key.pem -config=cfssl-config.json 
 cfssl bundle -cert server-from-root.pem -ca-bundle root-ca.pem | jq '. | {"result": {"bundle": .}}' | cfssljson -bare server-from-root
 cfssl gencert -ca intermediate-ca.pem -ca-key intermediate-ca-key.pem -config=cfssl-config.json -profile=server server-csr.json | cfssljson -bare server-from-intermediate
 cfssl bundle -cert server-from-intermediate.pem -ca-bundle root-ca.pem -int-bundle intermediate-ca.pem | jq '. | {"result": {"bundle": .}}' | cfssljson -bare server-from-intermediate
+
+# https://stackoverflow.com/questions/40312562/my-ssl-cert-chain-is-missing-a-subject
+cat >server-nosubject-csr.json <<EOF
+{
+  "CN": "",
+  "hosts": [
+    "pemtokeystore.tld",
+    "127.0.0.1",
+    "localhost"
+  ],
+  "key": {
+    "algo": "ecdsa",
+    "size": 256
+  },
+  "names": [
+    {
+    }
+  ]
+}
+EOF
+
+cfssl gencert -ca root-ca.pem -ca-key root-ca-key.pem -config=cfssl-config.json -profile=server server-nosubject-csr.json | cfssljson -bare server-nosubject-from-root
+cfssl bundle -cert server-nosubject-from-root.pem -ca-bundle root-ca.pem | jq '. | {"result": {"bundle": .}}' | cfssljson -bare server-nosubject-from-root


### PR DESCRIPTION
Not sure how you will feel about this, but here it comes :)

I see this is primarily a CLI project, but for me it's more useful as a library.

In memory conversion gets relevant when you get your certs from an API and just push the converted version towards another API.

It can also be relevant if you want to avoid touching disk when dealing with private certs for example.

Tried to be backwards compatible, but didn't know how to deal with the required input keystore and I simply removed that branch and replaced it with an empty keystore. Will try to find a better way if you like this stuff overall, but we will see :)